### PR TITLE
Zwrite

### DIFF
--- a/SPM-Project/Assets/Prefabs/Player.prefab
+++ b/SPM-Project/Assets/Prefabs/Player.prefab
@@ -899,6 +899,7 @@ GameObject:
   - component: {fileID: 7841059611673499744}
   - component: {fileID: 7841059611673499759}
   - component: {fileID: 7841059611673499746}
+  - component: {fileID: 8955925705087128327}
   m_Layer: 11
   m_Name: PlayerCamera
   m_TagString: MainCamera
@@ -996,6 +997,18 @@ MonoBehaviour:
   camRadius: 0.25
   minCollisionDistance: 2.5
   playerMesh: {fileID: 2852529094400065823}
+--- !u!114 &8955925705087128327
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7841059611673499758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c98645c72e3711c4f8d1c9220662cb96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7841059611711259448
 GameObject:
   m_ObjectHideFlags: 0

--- a/SPM-Project/Assets/Prefabs/System/FixZWrite.prefab
+++ b/SPM-Project/Assets/Prefabs/System/FixZWrite.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &110724686938391087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 110724686938391085}
+  - component: {fileID: 110724686938391086}
+  m_Layer: 0
+  m_Name: FixZWrite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &110724686938391085
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110724686938391087}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -13.955058, y: 15.407935, z: 3.6375608}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &110724686938391086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110724686938391087}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c98645c72e3711c4f8d1c9220662cb96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mrs: []

--- a/SPM-Project/Assets/Prefabs/System/FixZWrite.prefab
+++ b/SPM-Project/Assets/Prefabs/System/FixZWrite.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 110724686938391087}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -13.955058, y: 15.407935, z: 3.6375608}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -43,4 +43,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c98645c72e3711c4f8d1c9220662cb96, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mrs: []
+  MeshRenderers: []

--- a/SPM-Project/Assets/Prefabs/System/FixZWrite.prefab.meta
+++ b/SPM-Project/Assets/Prefabs/System/FixZWrite.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5ee900c22f9010b4ea851394cb99b73b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Scenes/ViktorD.unity
+++ b/SPM-Project/Assets/Scenes/ViktorD.unity
@@ -998,6 +998,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 09c76aa4a4f019c41a45cfc9c75d0027, type: 3}
+--- !u!23 &897934483 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 3478167427223906294, guid: 09c76aa4a4f019c41a45cfc9c75d0027,
+    type: 3}
+  m_PrefabInstance: {fileID: 840044201}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &942740573
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1290,7 +1296,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d7bb43a697221e248a6d180879973c31, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -2093,6 +2099,85 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1001 &110724686554387735
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.955058
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15.407935
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.6375608
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391086, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: mrs.Array.data[0]
+      value: 
+      objectReference: {fileID: 1125928482}
+    - target: {fileID: 110724686938391086, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: mrs.Array.data[1]
+      value: 
+      objectReference: {fileID: 897934483}
+    - target: {fileID: 110724686938391087, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: m_Name
+      value: FixZWrite
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5ee900c22f9010b4ea851394cb99b73b, type: 3}
 --- !u!1001 &1870566030044500736
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/SPM-Project/Assets/Scenes/ViktorD.unity
+++ b/SPM-Project/Assets/Scenes/ViktorD.unity
@@ -996,6 +996,11 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7841059611673499746, guid: 09c76aa4a4f019c41a45cfc9c75d0027,
+        type: 3}
+      propertyPath: playerLayer.m_Bits
+      value: 2048
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 09c76aa4a4f019c41a45cfc9c75d0027, type: 3}
 --- !u!23 &897934483 stripped
@@ -2108,41 +2113,6 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
         type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -13.955058
-      objectReference: {fileID: 0}
-    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 15.407935
-      objectReference: {fileID: 0}
-    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 3.6375608
-      objectReference: {fileID: 0}
-    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 110724686938391085, guid: 5ee900c22f9010b4ea851394cb99b73b,
-        type: 3}
       propertyPath: m_RootOrder
       value: 30
       objectReference: {fileID: 0}
@@ -2163,12 +2133,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 110724686938391086, guid: 5ee900c22f9010b4ea851394cb99b73b,
         type: 3}
+      propertyPath: MeshRenderers.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 110724686938391086, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
       propertyPath: mrs.Array.data[0]
       value: 
       objectReference: {fileID: 1125928482}
     - target: {fileID: 110724686938391086, guid: 5ee900c22f9010b4ea851394cb99b73b,
         type: 3}
       propertyPath: mrs.Array.data[1]
+      value: 
+      objectReference: {fileID: 897934483}
+    - target: {fileID: 110724686938391086, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: MeshRenderers.Array.data[0]
+      value: 
+      objectReference: {fileID: 1125928482}
+    - target: {fileID: 110724686938391086, guid: 5ee900c22f9010b4ea851394cb99b73b,
+        type: 3}
+      propertyPath: MeshRenderers.Array.data[1]
       value: 
       objectReference: {fileID: 897934483}
     - target: {fileID: 110724686938391087, guid: 5ee900c22f9010b4ea851394cb99b73b,

--- a/SPM-Project/Assets/Scripts/FixZWrite.cs
+++ b/SPM-Project/Assets/Scripts/FixZWrite.cs
@@ -3,22 +3,25 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class FixZWrite : MonoBehaviour {
-	
-	/// <summary>
-	/// The mesh renderers whose materials to enable Z-writing on.
-	/// </summary>
-	public MeshRenderer[] MeshRenderers;
+
+	private int count;
 	
 	private void Start() {
-		for (int i = 0; i < MeshRenderers.Length; i++) {
-			EnableZWrite(MeshRenderers[i]);	
+		GameObject[] allGameObjects = FindObjectsOfType<GameObject>();
+		for (int i = 0; i < allGameObjects.Length; i++) {
+			if (allGameObjects[i].activeInHierarchy) EnableZWrite(allGameObjects[i].GetComponent<MeshRenderer>());
 		}
+		Debug.LogWarning("Changed _ZWrite for " + count + " objects.");
 	}
 
 	private void EnableZWrite(MeshRenderer mr) {
-		Material m = new Material(mr.material);
-		mr.material = m;
-		m.SetInt("_ZWrite", 1);
+		if (mr == null) return;
+		if (mr.material.GetFloat("_Mode") == 3f) {
+			Material m = new Material(mr.material);
+			mr.material = m;
+			m.SetInt("_ZWrite", 1);
+			count++;
+		}
 	}
 
 }

--- a/SPM-Project/Assets/Scripts/FixZWrite.cs
+++ b/SPM-Project/Assets/Scripts/FixZWrite.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FixZWrite : MonoBehaviour {
+	
+	/// <summary>
+	/// The mesh renderers whose materials to enable Z-writing on.
+	/// </summary>
+	public MeshRenderer[] MeshRenderers;
+	
+	private void Start() {
+		for (int i = 0; i < MeshRenderers.Length; i++) {
+			EnableZWrite(MeshRenderers[i]);	
+		}
+	}
+
+	private void EnableZWrite(MeshRenderer mr) {
+		Material m = new Material(mr.material);
+		mr.material = m;
+		m.SetInt("_ZWrite", 1);
+	}
+
+}

--- a/SPM-Project/Assets/Scripts/FixZWrite.cs.meta
+++ b/SPM-Project/Assets/Scripts/FixZWrite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c98645c72e3711c4f8d1c9220662cb96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This branch adds a tool to fix Z buffer writing for material shaders. All you gotta do is place the prefab in the scene, then assign meshrenderers with transparent materials (including the player mesh) to the array. If the GameObject only has 1 meshrenderer you can drag and drop the whole thing.