### PR TITLE
Physics Material Restructure

### DIFF
--- a/SPM-Project/Assets/Materials/PhysicsMaterials/Player.physicMaterial
+++ b/SPM-Project/Assets/Materials/PhysicsMaterials/Player.physicMaterial
@@ -6,7 +6,7 @@ PhysicMaterial:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: GenericGeometry
+  m_Name: Player
   dynamicFriction: 0
   staticFriction: 0
   bounciness: 0

--- a/SPM-Project/Assets/Materials/PhysicsMaterials/Player.physicMaterial.meta
+++ b/SPM-Project/Assets/Materials/PhysicsMaterials/Player.physicMaterial.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 57319a2a11999b54dabe5cd2522a9adc
+guid: 0958ca23a2939bf4d86c17a4e343eeab
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/SPM-Project/Assets/Prefabs/Player.prefab
+++ b/SPM-Project/Assets/Prefabs/Player.prefab
@@ -491,7 +491,7 @@ CapsuleCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7841059610958226992}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: 0958ca23a2939bf4d86c17a4e343eeab, type: 2}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 1.25


### PR DESCRIPTION
If you don't notice a difference, this branch is working as intended.
This branch moves the custom physics material to the player, so that level geometry colliders don't need to be assigned a physics material, as well as letting non-player rigidbodies interact with the level geometry normally, which in turn should solve the sliding issue in the Drops branch.