### PR TITLE
Rotation Zones

### DIFF
--- a/SPM-Project/Assets/Prefabs/System/RotationZone.prefab
+++ b/SPM-Project/Assets/Prefabs/System/RotationZone.prefab
@@ -1,0 +1,61 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4447607972666524214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4447607972666524212}
+  - component: {fileID: 4447607972666524213}
+  - component: {fileID: 4447607972666524211}
+  m_Layer: 0
+  m_Name: RotationZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4447607972666524212
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4447607972666524214}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.35, y: 3.63, z: -3.28}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4447607972666524213
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4447607972666524214}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 5, y: 5, z: 5}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4447607972666524211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4447607972666524214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdf152cf533f6af4d961cca70bc4aac4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationX: 0
+  rotationY: 0

--- a/SPM-Project/Assets/Prefabs/System/RotationZone.prefab.meta
+++ b/SPM-Project/Assets/Prefabs/System/RotationZone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fb4b8f7744443e24f936826f6a6c9d30
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Scenes/ViktorD.unity
+++ b/SPM-Project/Assets/Scenes/ViktorD.unity
@@ -2799,6 +2799,75 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3746d56abc0603f46bb17350579e4835, type: 3}
+--- !u!1001 &4447607971300289007
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4447607972666524214, guid: fb4b8f7744443e24f936826f6a6c9d30,
+        type: 3}
+      propertyPath: m_Name
+      value: RotationZone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fb4b8f7744443e24f936826f6a6c9d30, type: 3}
 --- !u!1001 &5164862923522581693
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/SPM-Project/Assets/Scenes/ViktorD.unity
+++ b/SPM-Project/Assets/Scenes/ViktorD.unity
@@ -2824,22 +2824,22 @@ PrefabInstance:
     - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: 0.38574508
       objectReference: {fileID: 0}
     - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.9226054
       objectReference: {fileID: 0}
     - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
         type: 3}
@@ -2854,7 +2854,7 @@ PrefabInstance:
     - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 45.38
       objectReference: {fileID: 0}
     - target: {fileID: 4447607972666524212, guid: fb4b8f7744443e24f936826f6a6c9d30,
         type: 3}

--- a/SPM-Project/Assets/Scripts/PlayerCamera.cs
+++ b/SPM-Project/Assets/Scripts/PlayerCamera.cs
@@ -99,6 +99,18 @@ public class PlayerCamera : MonoBehaviour {
 	}
 
 	/// <summary>
+	/// Sets rotation values to the camera that won't be overwritten by the internal rotation script.
+	/// </summary>
+	/// <param name="rotationX">The desired rotation around the X axis.</param>
+	/// <param name="rotationY">The desired rotation around the Y axis.</param>
+	public void InjectSetRotation(float rotationX, float rotationY) {
+		this.rotationY = rotationY;
+		this.rotationX = rotationX;
+		this.rotationX = Mathf.Clamp(this.rotationX, -60f, 60f);
+		transform.rotation = Quaternion.Euler(this.rotationX, this.rotationY, 0);
+	}
+
+	/// <summary>
 	/// Needs to be public to allow for setting camera FoV in the STM. /E
 	/// </summary>
 	/// <param name="fov">The cameras field of view value.</param>

--- a/SPM-Project/Assets/Scripts/RotationZone.cs
+++ b/SPM-Project/Assets/Scripts/RotationZone.cs
@@ -4,12 +4,9 @@ using UnityEngine;
 
 public class RotationZone : MonoBehaviour {
 
-	[SerializeField] private float rotationX;
-	[SerializeField] private float rotationY;
-
 	private void OnTriggerEnter(Collider other) {
 		if (other.gameObject.CompareTag("Player")) {
-			other.gameObject.GetComponentInChildren<PlayerCamera>().InjectSetRotation(rotationX, rotationY);
+			other.gameObject.GetComponentInChildren<PlayerCamera>().InjectSetRotation(transform.rotation.eulerAngles.x, transform.rotation.eulerAngles.y);
 			gameObject.SetActive(false);
 		}
 	}

--- a/SPM-Project/Assets/Scripts/RotationZone.cs
+++ b/SPM-Project/Assets/Scripts/RotationZone.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RotationZone : MonoBehaviour {
+
+	[SerializeField] private float rotationX;
+	[SerializeField] private float rotationY;
+
+	private void OnTriggerEnter(Collider other) {
+		if (other.gameObject.CompareTag("Player")) {
+			other.gameObject.GetComponentInChildren<PlayerCamera>().InjectSetRotation(rotationX, rotationY);
+			gameObject.SetActive(false);
+		}
+	}
+
+}

--- a/SPM-Project/Assets/Scripts/RotationZone.cs.meta
+++ b/SPM-Project/Assets/Scripts/RotationZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdf152cf533f6af4d961cca70bc4aac4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This branch adds "rotation zones"; a prefab that will force its own rotation upon the player camera when the player enters its collider. After the rotation has been changed it will disable itself. I made this tool because it was an easy way to solve the issue of the player facing the wrong direction when spawning into levels.