### PR TITLE
ZWrite Fix

### DIFF
--- a/SPM-Project/Assets/Prefabs/Player.prefab
+++ b/SPM-Project/Assets/Prefabs/Player.prefab
@@ -1849,7 +1849,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7841059611673499758}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c98645c72e3711c4f8d1c9220662cb96, type: 3}
   m_Name: 

--- a/SPM-Project/Assets/Scripts/System/FixZWrite.cs
+++ b/SPM-Project/Assets/Scripts/System/FixZWrite.cs
@@ -21,10 +21,8 @@ public class FixZWrite : MonoBehaviour {
 		if (mr == null) return;
 		switch (mr.sharedMaterial.shader.name) {
 			case "Standard":
-				if (mr.sharedMaterial.GetFloat("_Mode") == 3f) {
-					Material m = new Material(mr.sharedMaterial);
-					mr.sharedMaterial = m;
-					m.SetInt("_ZWrite", 1);
+				if (mr.sharedMaterial.GetFloat("_Mode") == 3f) {;
+					mr.material.SetInt("_ZWrite", 1);
 					count++;
 				}
 				break;

--- a/SPM-Project/Assets/Scripts/System/FixZWrite.cs
+++ b/SPM-Project/Assets/Scripts/System/FixZWrite.cs
@@ -8,7 +8,7 @@ public class FixZWrite : MonoBehaviour {
 	private int count;
 
 	private List<string> warnings = new List<string>();
-	
+
 	private void Start() {
 		GameObject[] allGameObjects = FindObjectsOfType<GameObject>();
 		for (int i = 0; i < allGameObjects.Length; i++) {
@@ -19,19 +19,19 @@ public class FixZWrite : MonoBehaviour {
 
 	private void EnableZWrite(MeshRenderer mr) {
 		if (mr == null) return;
-		switch (mr.material.shader.name) {
+		switch (mr.sharedMaterial.shader.name) {
 			case "Standard":
-				if (mr.material.GetFloat("_Mode") == 3f) {
-					Material m = new Material(mr.material);
-					mr.material = m;
+				if (mr.sharedMaterial.GetFloat("_Mode") == 3f) {
+					Material m = new Material(mr.sharedMaterial);
+					mr.sharedMaterial = m;
 					m.SetInt("_ZWrite", 1);
 					count++;
 				}
 				break;
 			default:
-				if (!warnings.Contains(mr.material.shader.name)) {
-					Debug.LogWarning("Unsupported shader: " + mr.material.shader.name);
-					warnings.Add(mr.material.shader.name);
+				if (!warnings.Contains(mr.sharedMaterial.shader.name)) {
+					Debug.LogWarning("Unsupported shader: " + mr.sharedMaterial.shader.name);
+					warnings.Add(mr.sharedMaterial.shader.name);
 				}
 				break;
 		}


### PR DESCRIPTION
ZWrite was accessing the material property of every material in the scene, which so happens to break batching. When the property is accessed an instance is created, making that material functionally different from others of the same sharedmaterial.