### PR TITLE
Camera Follow

### DIFF
--- a/SPM-Project/Assets/Packages.meta
+++ b/SPM-Project/Assets/Packages.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84be4401909e9ec42934e2a9cf0de5f4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Packages/MediumMechStriker.meta
+++ b/SPM-Project/Assets/Packages/MediumMechStriker.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84eacb9e0b3304344989b9f1cbab13ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Packages/MediumMechStriker/FBX.meta
+++ b/SPM-Project/Assets/Packages/MediumMechStriker/FBX.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cdb7da673079eba49b018b3d957a2cd6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Packages/MediumMechStriker/FBX/MediumMechStriker.meta
+++ b/SPM-Project/Assets/Packages/MediumMechStriker/FBX/MediumMechStriker.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4acfee82d3aca39418683038ef8f4f30
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Packages/MediumMechStriker/FBX/MediumMechStriker/Materials.meta
+++ b/SPM-Project/Assets/Packages/MediumMechStriker/FBX/MediumMechStriker/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bd5b0894e012ce47b5a2dc6d4fcd19a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Prefabs/Player.prefab
+++ b/SPM-Project/Assets/Prefabs/Player.prefab
@@ -824,7 +824,7 @@ MonoBehaviour:
   thrust2: {fileID: 3745030277368027055}
   dash1: {fileID: 3790685401954395183}
   dash2: {fileID: 3057476334920611650}
-  rotationSpeed: 10
+  rotationSpeed: 20
   playerAnimator: {fileID: 6358656477459953120}
 --- !u!114 &7841059610958226997
 MonoBehaviour:

--- a/SPM-Project/Assets/Prefabs/Player.prefab
+++ b/SPM-Project/Assets/Prefabs/Player.prefab
@@ -105,7 +105,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7841059610958226996}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4584773652630041271
 MonoBehaviour:
@@ -768,7 +768,6 @@ Transform:
   - {fileID: 6358656477450361364}
   - {fileID: 2852529094400065823}
   - {fileID: 7841059610537404105}
-  - {fileID: 7841059611673499745}
   - {fileID: 2965801763724568574}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -805,7 +804,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5936724643d1f5b4081626c8db9943de, type: 2}
   - {fileID: 11400000, guid: 248b71c3989f24846ad3162667c5cf28, type: 2}
   - {fileID: 11400000, guid: db4b5d507fe558a4c8b7375400d537f8, type: 2}
-  cam: {fileID: 7841059611673499746}
+  cam: {fileID: 0}
   playerHud: {fileID: 7841059610537404106}
   audioClips:
   - {fileID: 8300000, guid: 3bb0b18438964b04a89eb9476d3bc2e9, type: 3}
@@ -1730,168 +1729,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &7841059611673499758
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7841059611673499745}
-  - component: {fileID: 7841059611673499744}
-  - component: {fileID: 7841059611673499759}
-  - component: {fileID: 7841059611673499746}
-  - component: {fileID: 8955925705087128327}
-  - component: {fileID: 5227034916481503275}
-  - component: {fileID: 5407256558300367852}
-  m_Layer: 11
-  m_Name: PlayerCamera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7841059611673499745
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7841059611673499758}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 3, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 7841059610958226996}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!20 &7841059611673499744
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7841059611673499758}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!81 &7841059611673499759
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7841059611673499758}
-  m_Enabled: 1
---- !u!114 &7841059611673499746
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7841059611673499758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db5defdd5c8885e47a11a2924e46cac9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  states:
-  - {fileID: 11400000, guid: c53acc6cd254e304a8a77ab9988fa508, type: 2}
-  - {fileID: 11400000, guid: 01166ec7491247445b59e4e0d07efd0b, type: 2}
-  collisionLayer:
-    serializedVersion: 2
-    m_Bits: 1536
-  playerLayer:
-    serializedVersion: 2
-    m_Bits: 2048
-  lookSensitivity: 1
-  camRadius: 0.25
-  minCollisionDistance: 2.5
-  playerMesh: {fileID: 2852529094400065823}
-  reverbZoned: 0
---- !u!114 &8955925705087128327
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7841059611673499758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c98645c72e3711c4f8d1c9220662cb96, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &5227034916481503275
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7841059611673499758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b91fa3c146192b14685d483fe4cb7c0a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isEnabled: 0
---- !u!114 &5407256558300367852
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7841059611673499758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad0d165281873cb4aaddb4e193226645, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  currentMode: 0
-  renderModes:
-  - Keyword: 0
-    Materials:
-    - {fileID: 2100000, guid: 2d306e2f40d5872469a1ebc3e86e2cea, type: 2}
-  - Keyword: 1
-    Materials:
-    - {fileID: 2100000, guid: 7a4a61e1a11dd924ba102561c770aacf, type: 2}
-  playerRenderers:
-  - {fileID: 6358656477464185632}
-  - {fileID: 6358656477464185634}
-  - {fileID: 6358656477464185636}
 --- !u!1 &7841059611711259448
 GameObject:
   m_ObjectHideFlags: 0
@@ -2446,72 +2283,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b0c68e6eb763a604694ce6e49557bfb4, type: 3}
---- !u!4 &6358656477450361376 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400032, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361348 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400004, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361382 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400038, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361374 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400030, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361390 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400046, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!137 &6358656477464185636 stripped
-SkinnedMeshRenderer:
-  m_CorrespondingSourceObject: {fileID: 13700004, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361370 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400026, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!137 &6358656477464185634 stripped
-SkinnedMeshRenderer:
-  m_CorrespondingSourceObject: {fileID: 13700002, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361360 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400016, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361380 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400036, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361346 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400002, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6358656477450361354 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400010, guid: b0c68e6eb763a604694ce6e49557bfb4,
@@ -2527,24 +2298,6 @@ Transform:
 --- !u!4 &6358656477450361378 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400034, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!137 &6358656477464185632 stripped
-SkinnedMeshRenderer:
-  m_CorrespondingSourceObject: {fileID: 13700000, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6358656477450361350 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400006, guid: b0c68e6eb763a604694ce6e49557bfb4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6358656477450485888}
-  m_PrefabAsset: {fileID: 0}
---- !u!95 &6358656477459953120 stripped
-Animator:
-  m_CorrespondingSourceObject: {fileID: 9500000, guid: b0c68e6eb763a604694ce6e49557bfb4,
     type: 3}
   m_PrefabInstance: {fileID: 6358656477450485888}
   m_PrefabAsset: {fileID: 0}
@@ -2566,15 +2319,81 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6358656477450485888}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400016, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6358656477450361364 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400020, guid: b0c68e6eb763a604694ce6e49557bfb4,
     type: 3}
   m_PrefabInstance: {fileID: 6358656477450485888}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361370 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400026, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361350 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400006, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6358656477450361384 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400040, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361376 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400032, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361348 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400004, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &6358656477459953120 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 9500000, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361382 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400038, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361374 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400030, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361390 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400046, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361380 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400036, guid: b0c68e6eb763a604694ce6e49557bfb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6358656477450485888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6358656477450361346 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400002, guid: b0c68e6eb763a604694ce6e49557bfb4,
     type: 3}
   m_PrefabInstance: {fileID: 6358656477450485888}
   m_PrefabAsset: {fileID: 0}

--- a/SPM-Project/Assets/Prefabs/Player.prefab
+++ b/SPM-Project/Assets/Prefabs/Player.prefab
@@ -824,6 +824,7 @@ MonoBehaviour:
   thrust2: {fileID: 3745030277368027055}
   dash1: {fileID: 3790685401954395183}
   dash2: {fileID: 3057476334920611650}
+  rotationSpeed: 10
   playerAnimator: {fileID: 6358656477459953120}
 --- !u!114 &7841059610958226997
 MonoBehaviour:

--- a/SPM-Project/Assets/Prefabs/PlayerCamera.prefab
+++ b/SPM-Project/Assets/Prefabs/PlayerCamera.prefab
@@ -1,0 +1,164 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8446956504242689143
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 768064164047327651}
+  - component: {fileID: 1679467440449435663}
+  - component: {fileID: 7532085943279808120}
+  - component: {fileID: 6349706981074172183}
+  - component: {fileID: 4082927896949736457}
+  - component: {fileID: 1192665678275053274}
+  - component: {fileID: 8823358252018390622}
+  m_Layer: 11
+  m_Name: PlayerCamera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &768064164047327651
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446956504242689143}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 5.1, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &1679467440449435663
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446956504242689143}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &7532085943279808120
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446956504242689143}
+  m_Enabled: 1
+--- !u!114 &6349706981074172183
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446956504242689143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db5defdd5c8885e47a11a2924e46cac9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  states:
+  - {fileID: 11400000, guid: c53acc6cd254e304a8a77ab9988fa508, type: 2}
+  - {fileID: 11400000, guid: 01166ec7491247445b59e4e0d07efd0b, type: 2}
+  collisionLayer:
+    serializedVersion: 2
+    m_Bits: 1536
+  playerLayer:
+    serializedVersion: 2
+    m_Bits: 2048
+  lookSensitivity: 1
+  camRadius: 0.25
+  minCollisionDistance: 2.5
+  playerMesh: {fileID: 0}
+  reverbZoned: 0
+--- !u!114 &4082927896949736457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446956504242689143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c98645c72e3711c4f8d1c9220662cb96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1192665678275053274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446956504242689143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b91fa3c146192b14685d483fe4cb7c0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isEnabled: 0
+--- !u!114 &8823358252018390622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446956504242689143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad0d165281873cb4aaddb4e193226645, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentMode: 0
+  renderModes:
+  - Keyword: 0
+    Materials:
+    - {fileID: 2100000, guid: 2d306e2f40d5872469a1ebc3e86e2cea, type: 2}
+  - Keyword: 1
+    Materials:
+    - {fileID: 2100000, guid: 7a4a61e1a11dd924ba102561c770aacf, type: 2}
+  playerRenderers:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}

--- a/SPM-Project/Assets/Prefabs/PlayerCamera.prefab.meta
+++ b/SPM-Project/Assets/Prefabs/PlayerCamera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3de3ce3ebe7f8c447849053d669a7444
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPM-Project/Assets/Scenes/Dev/ViktorD.unity
+++ b/SPM-Project/Assets/Scenes/Dev/ViktorD.unity
@@ -469,7 +469,7 @@ Transform:
   - {fileID: 1735744328}
   - {fileID: 749520767}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &371819692 stripped
 Transform:
@@ -1231,7 +1231,7 @@ PrefabInstance:
     - target: {fileID: 7841059610958226996, guid: 09c76aa4a4f019c41a45cfc9c75d0027,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7841059610958226996, guid: 09c76aa4a4f019c41a45cfc9c75d0027,
         type: 3}
@@ -2345,7 +2345,7 @@ PrefabInstance:
     - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
         type: 3}
@@ -3047,7 +3047,7 @@ PrefabInstance:
     - target: {fileID: 7626634061086666969, guid: 334abebd7026ff243a85bff259c19e0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7626634061086666969, guid: 334abebd7026ff243a85bff259c19e0a,
         type: 3}
@@ -3298,7 +3298,7 @@ PrefabInstance:
     - target: {fileID: 5164862922155292314, guid: c69ff102103f8a34ba0e12172a40c911,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5164862922155292314, guid: c69ff102103f8a34ba0e12172a40c911,
         type: 3}
@@ -3391,6 +3391,95 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ae415aec4188a66478c82ecdb3fd4896, type: 3}
+--- !u!1001 &5410541741742973266
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 768064164047327651, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6349706981074172183, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: playerMesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8446956504242689143, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerCamera
+      objectReference: {fileID: 0}
+    - target: {fileID: 8823358252018390622, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: playerRenderers.Array.data[0]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8823358252018390622, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: playerRenderers.Array.data[1]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8823358252018390622, guid: 3de3ce3ebe7f8c447849053d669a7444,
+        type: 3}
+      propertyPath: playerRenderers.Array.data[2]
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3de3ce3ebe7f8c447849053d669a7444, type: 3}
 --- !u!1001 &6887533207048309165
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3579,7 +3668,7 @@ PrefabInstance:
     - target: {fileID: 8254532318942674061, guid: 715861eeed43d44469554fe78f20fada,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 8254532318942674061, guid: 715861eeed43d44469554fe78f20fada,
         type: 3}
@@ -3643,7 +3732,7 @@ PrefabInstance:
     - target: {fileID: 7794975306305105594, guid: 4127adb415061344aae0e11466b7a50a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7794975306305105594, guid: 4127adb415061344aae0e11466b7a50a,
         type: 3}
@@ -3717,7 +3806,7 @@ PrefabInstance:
     - target: {fileID: 5878737985512538775, guid: e1f4414e9eb7d564f9e475c074a1a833,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5878737985512538775, guid: e1f4414e9eb7d564f9e475c074a1a833,
         type: 3}

--- a/SPM-Project/Assets/Scenes/Dev/ViktorD.unity
+++ b/SPM-Project/Assets/Scenes/Dev/ViktorD.unity
@@ -1186,7 +1186,7 @@ PrefabInstance:
     - target: {fileID: 7841059610958226992, guid: 09c76aa4a4f019c41a45cfc9c75d0027,
         type: 3}
       propertyPath: m_Name
-      value: Player (1)
+      value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 7841059610958226992, guid: 09c76aa4a4f019c41a45cfc9c75d0027,
         type: 3}
@@ -2300,6 +2300,75 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1384ac3c693c8ad4ea20f21b2a0bc1fc, type: 3}
+--- !u!1001 &1642865754
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.972927
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 13.059415
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.265035
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722800, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714071856655722806, guid: d009a686e309a614c92796ac2b8b7317,
+        type: 3}
+      propertyPath: m_Name
+      value: FPSLimiter
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d009a686e309a614c92796ac2b8b7317, type: 3}
 --- !u!1001 &1645126346
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/SPM-Project/Assets/Scripts/Audio/ReverbZone.cs
+++ b/SPM-Project/Assets/Scripts/Audio/ReverbZone.cs
@@ -12,7 +12,7 @@ public class ReverbZone : MonoBehaviour {
 
     public void OnTriggerEnter(Collider other) {
         if (other.gameObject.CompareTag("Player")) {
-            other.gameObject.GetComponentInChildren<PlayerCamera>().reverbZoned ++;
+            other.gameObject.GetComponent<PlayerController>().Camera.reverbZoned ++;
             //other.gameObject.GetComponentInChildren<AudioReverbFilter>().reverbPreset = reverbPreset;
             //other.gameObject.GetComponentInChildren<AudioReverbFilter>().enabled = true;
             reverbSnapshot.TransitionTo(2);
@@ -21,9 +21,9 @@ public class ReverbZone : MonoBehaviour {
 
     void OnTriggerExit(Collider other) {
         if (other.gameObject.CompareTag("Player")) {
-            other.gameObject.GetComponentInChildren<PlayerCamera>().reverbZoned --;
-            //if (other.gameObject.GetComponentInChildren<PlayerCamera>().reverbZoned == 0) other.gameObject.GetComponentInChildren<AudioReverbFilter>().enabled = false;
-            if (other.gameObject.GetComponentInChildren<PlayerCamera>().reverbZoned == 0) defaultSnapshot.TransitionTo(2);
+            other.gameObject.GetComponent<PlayerController>().Camera.reverbZoned --;
+			//if (other.gameObject.GetComponent<PlayerController>().Camera.reverbZoned == 0) other.gameObject.GetComponentInChildren<AudioReverbFilter>().enabled = false;
+			if (other.gameObject.GetComponent<PlayerController>().Camera.reverbZoned == 0) defaultSnapshot.TransitionTo(2);
         }
     }
 }

--- a/SPM-Project/Assets/Scripts/InteractableVolume/RotationZone.cs
+++ b/SPM-Project/Assets/Scripts/InteractableVolume/RotationZone.cs
@@ -6,7 +6,7 @@ public class RotationZone : MonoBehaviour {
 
 	private void OnTriggerEnter(Collider other) {
 		if (other.gameObject.CompareTag("Player")) {
-			other.gameObject.GetComponentInChildren<PlayerCamera>().InjectSetRotation(transform.rotation.eulerAngles.x, transform.rotation.eulerAngles.y);
+			other.gameObject.GetComponent<PlayerController>().Camera.InjectSetRotation(transform.rotation.eulerAngles.x, transform.rotation.eulerAngles.y);
 			gameObject.SetActive(false);
 		}
 	}

--- a/SPM-Project/Assets/Scripts/Player/PlayerCamera.cs
+++ b/SPM-Project/Assets/Scripts/Player/PlayerCamera.cs
@@ -28,6 +28,7 @@ public class PlayerCamera : MonoBehaviour {
 	/// Rotation values for camera around the X and Y axes, determines where the player is "looking". /E
 	/// </summary>
 	private float rotationX, rotationY;
+	
 	/// <summary>
 	/// The camera's StateMachine instance (hereafter STM).
 	/// </summary>
@@ -51,16 +52,14 @@ public class PlayerCamera : MonoBehaviour {
 	{
 		stateMachine.Run();
 		AccumulateRotation();
+		
+		Debug.DrawRay(transform.position, transform.forward * 10);
+		
 	}
 
-	// I don't fully understand why we're doing camera updates in LateUpdate, 
-	// but the STM will run in Update /K
-	//Camera updates rotation in LateUpdate so that we don't try to change the rotation while the player is moving in a previous direction during the same frame.
-	//This can otherwise lead to wonky movement effects. /E
 	private void FixedUpdate() {
 		RotateCamera();
 		transform.position = playerMesh.position + GetAdjustedCameraPosition(transform.rotation * cameraOffset);
-		Debug.DrawRay(transform.position, transform.forward * 10);
 	}
 
 	private Vector3 GetAdjustedCameraPosition(Vector3 relationVector) {
@@ -144,4 +143,5 @@ public class PlayerCamera : MonoBehaviour {
 	public void SetSensitivity(float sensitivty) {
 		lookSensitivity = sensitivty;
 	}
+
 }

--- a/SPM-Project/Assets/Scripts/Player/PlayerCamera.cs
+++ b/SPM-Project/Assets/Scripts/Player/PlayerCamera.cs
@@ -52,14 +52,12 @@ public class PlayerCamera : MonoBehaviour {
 	{
 		stateMachine.Run();
 		AccumulateRotation();
-		
-		Debug.DrawRay(transform.position, transform.forward * 10);
-		
 	}
 
 	private void FixedUpdate() {
 		RotateCamera();
 		transform.position = playerMesh.position + GetAdjustedCameraPosition(transform.rotation * cameraOffset);
+		Debug.DrawRay(transform.position, transform.forward * 10);
 	}
 
 	private Vector3 GetAdjustedCameraPosition(Vector3 relationVector) {

--- a/SPM-Project/Assets/Scripts/Player/PlayerController.cs
+++ b/SPM-Project/Assets/Scripts/Player/PlayerController.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 public class PlayerController : MonoBehaviour, IEntity {
 
 	[SerializeField] [Tooltip("The player's possible states.")] private State[] states;
-	[SerializeField] [Tooltip("The player's camera.")] private PlayerCamera cam;
 	[SerializeField] [Tooltip("The player's HUD.")] private PlayerHud playerHud;
 	[SerializeField] private AudioClip[] audioClips;
 	[SerializeField] [Tooltip("Audio Source component #1")] private AudioSource audioSourceMain;
@@ -26,7 +25,7 @@ public class PlayerController : MonoBehaviour, IEntity {
 	/// <summary>
 	/// The camera targeting the player
 	/// </summary>
-	public PlayerCamera Camera { get => cam; }
+	public PlayerCamera Camera { get; private set; }
 
 	/// <summary>
 	/// Returns the player's current health, but can never be set from outside the player script.
@@ -71,6 +70,8 @@ public class PlayerController : MonoBehaviour, IEntity {
 		audioPlayerIdle.clip = audioClips[0];*/
 		audioPlayerIdle.Play();
 
+		Camera = UnityEngine.Camera.main.GetComponent<PlayerCamera>();
+
 		DebugManager.AddSection("Input", "Jump: ", "Dash: ");
 	}
 
@@ -80,7 +81,7 @@ public class PlayerController : MonoBehaviour, IEntity {
 		animHorizontal = UnityEngine.Input.GetAxis("Horizontal");
 		playerAnimator.SetFloat("Speed", animVertical);
 		playerAnimator.SetFloat("Direction", animHorizontal);
-		float yRot = cam.transform.rotation.eulerAngles.y;
+		float yRot = Camera.transform.rotation.eulerAngles.y;
 		transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(0, yRot, 0), rotationSpeed * Time.deltaTime);
 		Input.doJump = false;
 		Input.doDash = false;
@@ -100,7 +101,7 @@ public class PlayerController : MonoBehaviour, IEntity {
 	public Vector3 GetInput() {
 		Vector3 movementInput = new Vector3(UnityEngine.Input.GetAxisRaw("Horizontal"), 0, UnityEngine.Input.GetAxisRaw("Vertical"));
 		movementInput = movementInput.magnitude > 1 ? movementInput.normalized : movementInput;
-		Vector3 planarProjection = Vector3.ProjectOnPlane(cam.transform.rotation * movementInput, PhysicsBody.IsGrounded() ? PhysicsBody.GetCurrentSurfaceNormal().normalized : Vector3.up);
+		Vector3 planarProjection = Vector3.ProjectOnPlane(Camera.transform.rotation * movementInput, PhysicsBody.IsGrounded() ? PhysicsBody.GetCurrentSurfaceNormal().normalized : Vector3.up);
 		return planarProjection;
 	}
 

--- a/SPM-Project/Assets/Scripts/Player/PlayerController.cs
+++ b/SPM-Project/Assets/Scripts/Player/PlayerController.cs
@@ -12,6 +12,7 @@ public class PlayerController : MonoBehaviour, IEntity {
 	[SerializeField] [Tooltip("Audio Source component #3")] public AudioSource audioPlayerSteps;
 	[SerializeField] [Tooltip("Audio Source component #4")] private AudioSource audioPlayerIdle;
 	[SerializeField] public GameObject thrust1, thrust2, dash1, dash2;
+	[SerializeField] private float rotationSpeed;
 	public Animator playerAnimator;
 	private float animHorizontal, animVertical;
 
@@ -21,6 +22,11 @@ public class PlayerController : MonoBehaviour, IEntity {
 	public static PlayerController Instance;
 
 	private StateMachine stateMachine;
+
+	/// <summary>
+	/// The camera targeting the player
+	/// </summary>
+	public PlayerCamera Camera { get => cam; }
 
 	/// <summary>
 	/// Returns the player's current health, but can never be set from outside the player script.
@@ -75,7 +81,7 @@ public class PlayerController : MonoBehaviour, IEntity {
 		playerAnimator.SetFloat("Speed", animVertical);
 		playerAnimator.SetFloat("Direction", animHorizontal);
 		float yRot = cam.transform.rotation.eulerAngles.y;
-		transform.rotation = Quaternion.Euler(0, yRot, 0);
+		transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(0, yRot, 0), rotationSpeed * Time.deltaTime);
 		Input.doJump = false;
 		Input.doDash = false;
 	}

--- a/SPM-Project/Assets/Scripts/Player/PlayerRenderer.cs
+++ b/SPM-Project/Assets/Scripts/Player/PlayerRenderer.cs
@@ -9,11 +9,13 @@ public class PlayerRenderer : MonoBehaviour {
 
 	[SerializeField][Tooltip("and starting mode.")] private RenderMode currentMode;
 	[SerializeField] private RenderModeItem[] renderModes;
-	[SerializeField] private SkinnedMeshRenderer[] playerRenderers;
+	
+	private SkinnedMeshRenderer[] playerRenderers;
 
 	private Dictionary<RenderMode, Material[]> renderModeLookup;
 	
-	private void Awake() {
+	private void Start() {
+		playerRenderers = PlayerController.Instance.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
 		renderModeLookup = new Dictionary<RenderMode, Material[]>();
 		for (int i = 0; i < renderModes.Length; i++) {
 			renderModeLookup.Add(renderModes[i].Keyword, renderModes[i].Materials);


### PR DESCRIPTION
This branch was created to fix an issue where the camera movement would appear choppy, especially at lower frame rates (when rotating it, not merely moving around). One solution was to unparent the camera and have it follow the player on its own, but after some extensive testing I ultimately chose to let the player camera remain parented and instead let the player rotate more slowly. Indeed, the issue did not lie in the frame rate itself, but rather in the transition from a high frame rate to a lower one, or vice versa. This transitional choppyness was caused by the fix that made the camera turn speed frame rate independent: when we progressively changed frame rates over a period of time discrepancies were essentially created, which resulted in small rotational skips (I'm not 100% sure exactly how this works, but that was the problem and now it is solved).

Now, this fix - while addressing the issue - isn't 100% perfect. This is because of the rotation speed variable: a lower rotation speed makes the camera movement appear smoother, but it also naturally makes the player mesh rotate more slowly as well, which might not be entirely desirable. I found a decent rotation speed that I believe combines the best of both worlds, i.e. the mech rotation feels responsive enough, while simultaneously not jittering too much.

Comparison footage - ignore the back and forth camera movements along the Z axis (to accommodate for geometry):
Before:
![2020-05-14_19-18-06](https://user-images.githubusercontent.com/33043981/81964965-aaab7900-9617-11ea-9249-953c0c8dca9c.gif)
After:
![2020-05-14_19-20-25](https://user-images.githubusercontent.com/33043981/81965211-0413a800-9618-11ea-9100-8c146ba9fb8a.gif)